### PR TITLE
Add daily tasks checklist workflow

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,8 +1,10 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 export default function Header({
   title,
   subtitle,
+  roleLabel,
   tabs,
   activeTab,
   onTabChange,
@@ -23,6 +25,9 @@ export default function Header({
           <div>
             {subtitle && <p className="text-xs uppercase tracking-[0.2em] text-neutral-400">{subtitle}</p>}
             <h1 className="text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50">{title}</h1>
+            {roleLabel && (
+              <p className="text-xs font-medium text-neutral-500 dark:text-neutral-300">{roleLabel}</p>
+            )}
           </div>
           <div className="ml-auto flex items-center gap-3">
             <button
@@ -33,6 +38,12 @@ export default function Header({
             >
               {avatarInitial || <span className="sr-only">Open profile</span>}
             </button>
+            <Link
+              to="/"
+              className="inline-flex items-center gap-1.5 rounded-full border border-neutral-300/80 bg-white/85 px-4 py-2 text-sm font-semibold text-neutral-700 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-600 dark:border-neutral-700/80 dark:bg-neutral-900/70 dark:text-neutral-100 dark:focus-visible:outline-neutral-300"
+            >
+              View public site
+            </Link>
             <button
               type="button"
               onClick={onSignOut}

--- a/src/hooks/useDailyTasks.js
+++ b/src/hooks/useDailyTasks.js
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useState } from "react";
+import { supabase } from "../services/supabase";
+
+export const TASK_STATUSES = ["ongoing", "completed", "rejected"];
+
+const TODAY = () => new Date().toISOString().slice(0, 10);
+
+export function useDailyTasks(selectedDate) {
+  const [tasks, setTasks] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const refresh = useCallback(
+    async ({ silent = false } = {}) => {
+      if (!selectedDate) return;
+      if (!silent) setLoading(true);
+      const { data, error: fetchError } = await supabase
+        .from("daily_tasks")
+        .select("*")
+        .eq("task_date", selectedDate)
+        .order("created_at", { ascending: true });
+      setTasks(data || []);
+      setError(fetchError?.message || "");
+      setLoading(false);
+    },
+    [selectedDate]
+  );
+
+  const ensureCarryOver = useCallback(async () => {
+    if (!selectedDate) return;
+    const today = TODAY();
+    if (selectedDate !== today) return;
+
+    const { data: previousDay, error: prevError } = await supabase
+      .from("daily_tasks")
+      .select("task_date")
+      .lt("task_date", selectedDate)
+      .order("task_date", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (prevError) {
+      setError(prevError.message);
+      return;
+    }
+
+    const previousDate = previousDay?.task_date;
+    if (!previousDate) return;
+
+    const { data: previousTasks, error: previousTasksError } = await supabase
+      .from("daily_tasks")
+      .select("id,title,status,carry_over_from,user_id")
+      .eq("task_date", previousDate);
+
+    if (previousTasksError) {
+      setError(previousTasksError.message);
+      return;
+    }
+
+    if (!previousTasks?.length) return;
+
+    const incomplete = previousTasks.filter((task) => task.status !== "completed");
+    if (!incomplete.length) return;
+
+    const carryIds = incomplete.map((task) => task.carry_over_from || task.id);
+
+    if (!carryIds.length) return;
+
+    const { data: todaysTasks, error: todaysError } = await supabase
+      .from("daily_tasks")
+      .select("carry_over_from")
+      .eq("task_date", selectedDate)
+      .in("carry_over_from", carryIds);
+
+    if (todaysError) {
+      setError(todaysError.message);
+      return;
+    }
+
+    const existingCarry = new Set((todaysTasks || []).map((task) => task.carry_over_from).filter(Boolean));
+
+    const rowsToInsert = incomplete
+      .filter((task) => !existingCarry.has(task.carry_over_from || task.id))
+      .map((task) => ({
+        task_date: selectedDate,
+        title: task.title,
+        status: "ongoing",
+        verified: false,
+        verified_by: null,
+        verified_at: null,
+        remarks: null,
+        carry_over_from: task.carry_over_from || task.id,
+        user_id: task.user_id || null,
+      }));
+
+    if (!rowsToInsert.length) return;
+
+    const { error: insertError } = await supabase.from("daily_tasks").insert(rowsToInsert);
+    if (insertError) {
+      setError(insertError.message);
+    }
+  }, [selectedDate]);
+
+  useEffect(() => {
+    if (!selectedDate) return;
+    let ignore = false;
+
+    const initialise = async () => {
+      await ensureCarryOver();
+      if (!ignore) {
+        await refresh();
+      }
+    };
+
+    initialise();
+
+    const channel = supabase
+      .channel(`daily_tasks-${selectedDate}`)
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "daily_tasks" },
+        (payload) => {
+          if (ignore) return;
+          const changedDate = payload.new?.task_date || payload.old?.task_date;
+          if (!changedDate || changedDate === selectedDate) {
+            refresh({ silent: true });
+          }
+        }
+      )
+      .subscribe();
+
+    return () => {
+      ignore = true;
+      supabase.removeChannel(channel);
+    };
+  }, [selectedDate, ensureCarryOver, refresh]);
+
+  const addTask = useCallback(
+    async (title) => {
+      if (!selectedDate) return;
+      const trimmed = title.trim();
+      if (!trimmed) return;
+      const { data: userData } = await supabase.auth.getUser();
+      const userId = userData?.user?.id || null;
+      const { error: insertError } = await supabase.from("daily_tasks").insert({
+        title: trimmed,
+        task_date: selectedDate,
+        status: "ongoing",
+        user_id: userId,
+      });
+      if (insertError) {
+        alert(insertError.message);
+      }
+    },
+    [selectedDate]
+  );
+
+  const updateTask = useCallback(async (id, changes) => {
+    const payload = { ...changes, updated_at: new Date().toISOString() };
+    const { error: updateError } = await supabase.from("daily_tasks").update(payload).eq("id", id);
+    if (updateError) {
+      alert(updateError.message);
+    }
+  }, []);
+
+  const verifyTask = useCallback(
+    async (id, shouldVerify) => {
+      const { data: userData } = await supabase.auth.getUser();
+      const userId = userData?.user?.id || null;
+      if (shouldVerify) {
+        await updateTask(id, {
+          verified: true,
+          verified_by: userId,
+          verified_at: new Date().toISOString(),
+        });
+      } else {
+        await updateTask(id, {
+          verified: false,
+          verified_by: null,
+          verified_at: null,
+        });
+      }
+    },
+    [updateTask]
+  );
+
+  const deleteTask = useCallback(async (id) => {
+    const { error: deleteError } = await supabase.from("daily_tasks").delete().eq("id", id);
+    if (deleteError) {
+      alert(deleteError.message);
+    }
+  }, []);
+
+  return { tasks, loading, error, refresh, addTask, updateTask, verifyTask, deleteTask };
+}

--- a/src/hooks/usePublicDailyTasks.js
+++ b/src/hooks/usePublicDailyTasks.js
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { supabase } from "../services/supabase";
+
+export function usePublicDailyTasks() {
+  const [tasks, setTasks] = useState([]);
+  const [date, setDate] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const loadTasksForDate = useCallback(async (taskDate) => {
+    if (!taskDate) {
+      setTasks([]);
+      setLoading(false);
+      return;
+    }
+
+    const { data, error: tasksError } = await supabase
+      .from("daily_tasks")
+      .select(
+        "id,title,status,remarks,updated_at,updated_by,task_date,updated_by_profile:profiles!daily_tasks_updated_by_fkey(full_name,email)"
+      )
+      .eq("task_date", taskDate)
+      .order("created_at", { ascending: true });
+
+    if (tasksError) {
+      setError(tasksError.message);
+      setTasks([]);
+    } else {
+      setError("");
+      setTasks(data || []);
+    }
+
+    setLoading(false);
+  }, []);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError("");
+
+    const { data: latestDate, error: latestError } = await supabase
+      .from("daily_tasks")
+      .select("task_date")
+      .order("task_date", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (latestError) {
+      setError(latestError.message);
+      setTasks([]);
+      setDate("");
+      setLoading(false);
+      return;
+    }
+
+    const taskDate = latestDate?.task_date || "";
+    setDate(taskDate);
+    await loadTasksForDate(taskDate);
+  }, [loadTasksForDate]);
+
+  useEffect(() => {
+    refresh();
+    const channel = supabase
+      .channel("public-daily-tasks")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "daily_tasks" },
+        () => {
+          refresh();
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [refresh]);
+
+  const hasData = useMemo(() => tasks.length > 0, [tasks]);
+
+  return { tasks, date, loading, error, refresh, hasData };
+}

--- a/src/pages/reports.jsx
+++ b/src/pages/reports.jsx
@@ -28,6 +28,17 @@ const formatRole = (role) =>
         .replace(/_/g, " ")
         .replace(/\b\w/g, (char) => char.toUpperCase())
     : "Role not assigned";
+const formatDateTime = (value) => {
+  if (!value) return "";
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(value));
+  } catch (error) {
+    return value;
+  }
+};
 
 // --------- Session / Profile ---------
 function useSessionProfile(){
@@ -1008,6 +1019,18 @@ function DailyTaskItem({ task, canManageStatus, isAdmin, onStatusChange, onVerif
       return task.task_date;
     }
   }, [task.task_date]);
+  const updatedAtLabel = React.useMemo(() => formatDateTime(task.updated_at), [task.updated_at]);
+  const updatedByName = React.useMemo(() => {
+    const profile = task.updated_by_profile || {};
+    return profile.full_name?.trim() || profile.email || (task.updated_by ? "Team member" : "");
+  }, [task.updated_by, task.updated_by_profile]);
+  const updateMeta = React.useMemo(() => {
+    if (!updatedAtLabel && !updatedByName) return "";
+    const parts = [];
+    if (updatedAtLabel) parts.push(updatedAtLabel);
+    if (updatedByName) parts.push(`by ${updatedByName}`);
+    return `Last updated ${parts.join(" ")}`.trim();
+  }, [updatedAtLabel, updatedByName]);
 
   const handleSave = async () => {
     setSaving(true);
@@ -1040,6 +1063,9 @@ function DailyTaskItem({ task, canManageStatus, isAdmin, onStatusChange, onVerif
                 </span>
               )}
             </div>
+            {updateMeta && (
+              <p className="text-xs text-neutral-500 dark:text-neutral-400">{updateMeta}</p>
+            )}
           </div>
           {!isAdmin && task.remarks && (
             <p className="text-sm text-neutral-600 dark:text-neutral-300">

--- a/src/pages/reports.jsx
+++ b/src/pages/reports.jsx
@@ -3,6 +3,7 @@ import Header from "../components/Header";
 import Card from "../components/Card";
 import DataTable from "../components/DataTable";
 import { useTable } from "../hooks/useTable";
+import { useDailyTasks, TASK_STATUSES } from "../hooks/useDailyTasks";
 import { supabase, MISCONFIGURED } from "../services/supabase";
 import {
   ResponsiveContainer,
@@ -20,6 +21,13 @@ import {
   Legend,
 } from "recharts";
 const today = () => new Date().toISOString().slice(0, 10);
+const formatRole = (role) =>
+  role
+    ? role
+        .toString()
+        .replace(/_/g, " ")
+        .replace(/\b\w/g, (char) => char.toUpperCase())
+    : "Role not assigned";
 
 // --------- Session / Profile ---------
 function useSessionProfile(){
@@ -532,15 +540,18 @@ function RefreshButton({ onClick }) {
 // ========= Dashboard =========
 function Dashboard({ session, profile, refreshProfile }){
   const isAdmin = profile?.role === 'admin';
+  const isSupervisor = profile?.role === 'supervisor';
   const [tab, setTab] = React.useState('dashboard');
   const [showProfile, setShowProfile] = React.useState(false);
   const firstName = profile.full_name?.split(' ')[0] || 'User';
   const avatarInitial = firstName?.[0]?.toUpperCase() || 'U';
+  const roleLabel = formatRole(profile?.role);
   React.useEffect(() => {
     document.title = `${firstName}'s Site Reporting`;
   }, [firstName]);
   const tabs = [
     { value: 'dashboard', label: 'Dashboard' },
+    { value: 'tasks', label: 'Daily tasks' },
     { value: 'concrete', label: 'Concrete' },
     { value: 'manpower', label: 'Manpower' },
     { value: 'issues', label: 'Issues' },
@@ -560,10 +571,17 @@ function Dashboard({ session, profile, refreshProfile }){
         onEditProfile={() => setShowProfile(true)}
         onSignOut={handleSignOut}
         avatarInitial={avatarInitial}
+        roleLabel={roleLabel}
       />
 
       <main className="relative mx-auto grid max-w-7xl gap-6 px-6 pb-16 pt-10">
         {tab==='dashboard' && <DashboardTab />}
+        {tab==='tasks' && (
+          <DailyTasksLog
+            isAdmin={isAdmin}
+            isSupervisor={isSupervisor}
+          />
+        )}
         {tab==='concrete' && <ConcreteLog isAdmin={isAdmin} />}
         {tab==='manpower' && <ManpowerLog isAdmin={isAdmin} />}
         {tab==='issues' && <IssuesLog isAdmin={isAdmin} />}
@@ -821,6 +839,286 @@ function DashboardTab(){
         </div>
       )}
     </section>
+  );
+}
+
+function DailyTasksLog({ isAdmin, isSupervisor }){
+  const defaultDate = React.useMemo(() => today(), []);
+  const [selectedDate, setSelectedDate] = React.useState(defaultDate);
+  const [newTaskTitle, setNewTaskTitle] = React.useState("");
+  const { tasks, loading, error, refresh, addTask, updateTask, verifyTask, deleteTask } = useDailyTasks(selectedDate);
+  const canManageStatus = isAdmin || isSupervisor;
+  const readableDate = React.useMemo(() => {
+    try {
+      return new Intl.DateTimeFormat(undefined, { dateStyle: "long" }).format(
+        new Date(`${selectedDate}T00:00:00`)
+      );
+    } catch (e) {
+      return selectedDate;
+    }
+  }, [selectedDate]);
+
+  const handleAddTask = async (event) => {
+    event.preventDefault();
+    if (!newTaskTitle.trim()) return;
+    await addTask(newTaskTitle);
+    setNewTaskTitle("");
+  };
+
+  const handleStatusChange = async (task, nextStatus) => {
+    if (task.status === nextStatus) return;
+    const patch = { status: nextStatus };
+    if (nextStatus !== "completed") {
+      patch.verified = false;
+      patch.verified_by = null;
+      patch.verified_at = null;
+    }
+    await updateTask(task.id, patch);
+  };
+
+  const handleVerify = async (task, shouldVerify) => {
+    await verifyTask(task.id, shouldVerify);
+  };
+
+  const handleDelete = async (taskId) => {
+    if (!isAdmin) return;
+    if (!window.confirm("Delete this task?")) return;
+    await deleteTask(taskId);
+  };
+
+  const handleSaveRemark = async (taskId, remark) => {
+    await updateTask(taskId, { remarks: remark ? remark : null });
+  };
+
+  return (
+    <section className="grid gap-4">
+      <Card
+        title="Manage daily tasks"
+        subtitle="Assign tasks for the team and let supervisors update progress through the day."
+      >
+        <form
+          onSubmit={handleAddTask}
+          className="flex flex-col gap-4 rounded-2xl bg-white/40 p-4 text-sm shadow-sm ring-1 ring-white/40 backdrop-blur dark:bg-neutral-900/40 dark:ring-neutral-700/50 sm:flex-row sm:items-end"
+        >
+          <label className="flex flex-1 flex-col gap-1 text-sm">
+            <span className="text-xs font-medium uppercase tracking-widest text-neutral-500 dark:text-neutral-400">
+              Working date
+            </span>
+            <input
+              type="date"
+              value={selectedDate}
+              onChange={(event) => setSelectedDate(event.target.value)}
+              className="w-full rounded-xl border border-neutral-200/70 bg-white/90 px-3 py-2 text-neutral-900 shadow-sm outline-none transition focus:border-neutral-500 focus:ring-2 focus:ring-neutral-900/10 dark:border-neutral-700/70 dark:bg-neutral-900/70 dark:text-neutral-100 dark:focus:border-neutral-400 dark:focus:ring-neutral-100/20"
+            />
+          </label>
+          {canManageStatus && (
+            <div className="flex flex-1 flex-col gap-3 sm:flex-row sm:items-end">
+              <label className="flex-1 text-sm">
+                <span className="text-xs font-medium uppercase tracking-widest text-neutral-500 dark:text-neutral-400">
+                  New task
+                </span>
+                <input
+                  type="text"
+                  value={newTaskTitle}
+                  onChange={(event) => setNewTaskTitle(event.target.value)}
+                  placeholder="e.g. Morning toolbox briefing"
+                  className="mt-1 w-full rounded-xl border border-neutral-200/70 bg-white/90 px-3 py-2 text-neutral-900 shadow-sm outline-none transition placeholder:text-neutral-400 focus:border-neutral-500 focus:ring-2 focus:ring-neutral-900/10 dark:border-neutral-700/70 dark:bg-neutral-900/70 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-neutral-400 dark:focus:ring-neutral-100/20"
+                />
+              </label>
+              <button
+                type="submit"
+                className="inline-flex items-center justify-center rounded-xl bg-neutral-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-neutral-100 dark:text-neutral-900 dark:focus-visible:outline-neutral-300"
+                disabled={!newTaskTitle.trim()}
+              >
+                Add task
+              </button>
+            </div>
+          )}
+        </form>
+        <p className="mt-3 text-xs text-neutral-500 dark:text-neutral-400">
+          Tasks marked ongoing or rejected are automatically carried forward to the next working day. Supervisors can update
+          progress while admins can finalise remarks and verifications.
+        </p>
+      </Card>
+
+      <Card
+        title={`Tasks for ${readableDate}`}
+        actions={
+          <div className="ml-auto flex items-center gap-2">
+            <RefreshButton onClick={() => refresh()} />
+            <span className="text-xs text-neutral-500 dark:text-neutral-400">
+              {canManageStatus ? "Supervisors and admins can update status" : "Read-only access"}
+            </span>
+          </div>
+        }
+      >
+        <div className="flex flex-col gap-4">
+          {error && (
+            <p className="rounded-2xl bg-red-50/80 px-4 py-3 text-sm font-medium text-red-600 dark:bg-red-500/10 dark:text-red-300" role="alert">
+              {error}
+            </p>
+          )}
+          {loading && (
+            <p className="text-sm text-neutral-600 dark:text-neutral-300">Loading tasks…</p>
+          )}
+          {!loading && !tasks.length && !error && (
+            <p className="text-sm text-neutral-600 dark:text-neutral-300">
+              No tasks recorded for this date yet. {canManageStatus ? "Add the first task to start the checklist." : "Ask an administrator to create the checklist."}
+            </p>
+          )}
+          {!loading && tasks.length > 0 && (
+            <div className="grid gap-3">
+              {tasks.map((task) => (
+                <DailyTaskItem
+                  key={task.id}
+                  task={task}
+                  canManageStatus={canManageStatus}
+                  isAdmin={isAdmin}
+                  onStatusChange={handleStatusChange}
+                  onVerify={handleVerify}
+                  onDelete={handleDelete}
+                  onSaveRemark={handleSaveRemark}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </Card>
+    </section>
+  );
+}
+
+function DailyTaskItem({ task, canManageStatus, isAdmin, onStatusChange, onVerify, onDelete, onSaveRemark }){
+  const [remark, setRemark] = React.useState(task.remarks || "");
+  const [saving, setSaving] = React.useState(false);
+  const [dirty, setDirty] = React.useState(false);
+
+  React.useEffect(() => {
+    setRemark(task.remarks || "");
+    setDirty(false);
+  }, [task.id, task.remarks]);
+
+  const statusLabel = task.status ? task.status.charAt(0).toUpperCase() + task.status.slice(1) : "";
+  const taskDateLabel = React.useMemo(() => {
+    try {
+      return new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(
+        new Date(`${task.task_date}T00:00:00`)
+      );
+    } catch (error) {
+      return task.task_date;
+    }
+  }, [task.task_date]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    await onSaveRemark(task.id, remark.trim());
+    setSaving(false);
+    setDirty(false);
+  };
+
+  const disableVerify = task.status !== "completed";
+
+  return (
+    <div className="rounded-3xl border border-neutral-200/70 bg-white/85 p-5 shadow-sm transition dark:border-neutral-700/70 dark:bg-neutral-900/70">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 space-y-2">
+          <div>
+            <p className="text-base font-semibold text-neutral-900 dark:text-neutral-50">{task.title}</p>
+            <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400">
+              <span>{taskDateLabel}</span>
+              <span className="inline-flex items-center rounded-full bg-neutral-100 px-2 py-0.5 text-[0.7rem] font-medium uppercase tracking-wide text-neutral-600 dark:bg-neutral-800 dark:text-neutral-200">
+                {statusLabel}
+              </span>
+              {task.carry_over_from && (
+                <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[0.7rem] font-medium uppercase tracking-wide text-amber-700 dark:bg-amber-500/20 dark:text-amber-200">
+                  Carried over
+                </span>
+              )}
+              {task.verified && (
+                <span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-[0.7rem] font-medium uppercase tracking-wide text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200">
+                  Verified
+                </span>
+              )}
+            </div>
+          </div>
+          {!isAdmin && task.remarks && (
+            <p className="text-sm text-neutral-600 dark:text-neutral-300">
+              <span className="font-semibold">Remarks:</span> {task.remarks}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-col items-stretch gap-2 sm:items-end">
+          {canManageStatus ? (
+            <label className="text-xs font-medium uppercase tracking-widest text-neutral-500 dark:text-neutral-400">
+              Status
+              <select
+                value={task.status}
+                onChange={(event) => onStatusChange(task, event.target.value)}
+                className="mt-1 w-40 rounded-xl border border-neutral-200/70 bg-white/90 px-3 py-2 text-sm text-neutral-900 shadow-sm outline-none transition focus:border-neutral-500 focus:ring-2 focus:ring-neutral-900/10 dark:border-neutral-700/70 dark:bg-neutral-900/70 dark:text-neutral-100 dark:focus:border-neutral-400 dark:focus:ring-neutral-100/20"
+              >
+                {TASK_STATUSES.map((status) => (
+                  <option key={status} value={status}>
+                    {status.charAt(0).toUpperCase() + status.slice(1)}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : (
+            <p className="text-xs font-medium uppercase tracking-widest text-neutral-500 dark:text-neutral-400">
+              Status: {statusLabel}
+            </p>
+          )}
+          {isAdmin && (
+            <button
+              type="button"
+              onClick={() => onVerify(task, !task.verified)}
+              disabled={disableVerify && !task.verified}
+              className="inline-flex items-center justify-center rounded-full border border-neutral-300/80 bg-white/80 px-4 py-1.5 text-xs font-semibold text-neutral-700 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-600 dark:border-neutral-700/70 dark:bg-neutral-900/60 dark:text-neutral-200 dark:focus-visible:outline-neutral-300"
+            >
+              {task.verified ? "Remove verification" : "Verify task"}
+            </button>
+          )}
+          {isAdmin && (
+            <button
+              type="button"
+              onClick={() => onDelete(task.id)}
+              className="text-xs font-semibold text-red-600 underline-offset-4 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500/70 dark:text-red-300"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </div>
+
+      {isAdmin && (
+        <div className="mt-4">
+          <label className="text-xs font-medium uppercase tracking-widest text-neutral-500 dark:text-neutral-400">
+            Remarks
+            <textarea
+              value={remark}
+              onChange={(event) => {
+                setRemark(event.target.value);
+                setDirty(true);
+              }}
+              rows={3}
+              placeholder="Explain why a task was delayed or rejected"
+              className="mt-1 w-full rounded-xl border border-neutral-200/70 bg-white/90 px-3 py-2 text-sm text-neutral-900 shadow-sm outline-none transition placeholder:text-neutral-400 focus:border-neutral-500 focus:ring-2 focus:ring-neutral-900/10 dark:border-neutral-700/70 dark:bg-neutral-900/70 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-neutral-400 dark:focus:ring-neutral-100/20"
+            />
+          </label>
+          <div className="mt-2 flex flex-wrap items-center gap-3 text-xs">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving || !dirty}
+              className="inline-flex items-center justify-center rounded-full bg-neutral-900 px-4 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-neutral-100 dark:text-neutral-900 dark:focus-visible:outline-neutral-300"
+            >
+              {saving ? "Saving…" : "Save remark"}
+            </button>
+            {dirty && <span className="text-neutral-500 dark:text-neutral-300">Unsaved changes</span>}
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/supabase/migrations/20240715120000_create_daily_tasks.sql
+++ b/supabase/migrations/20240715120000_create_daily_tasks.sql
@@ -1,0 +1,34 @@
+create extension if not exists "pgcrypto";
+
+create or replace function public.set_current_timestamp_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create table if not exists public.daily_tasks (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users (id) on delete set null,
+  task_date date not null default current_date,
+  title text not null,
+  status text not null default 'ongoing',
+  verified boolean not null default false,
+  verified_by uuid references auth.users (id) on delete set null,
+  verified_at timestamptz,
+  remarks text,
+  carry_over_from uuid references public.daily_tasks (id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint daily_tasks_status_check check (status in ('completed', 'ongoing', 'rejected'))
+);
+
+create index if not exists daily_tasks_task_date_idx on public.daily_tasks (task_date);
+create index if not exists daily_tasks_status_idx on public.daily_tasks (status);
+create index if not exists daily_tasks_carry_idx on public.daily_tasks (carry_over_from);
+
+create trigger daily_tasks_updated_at
+before update on public.daily_tasks
+for each row
+execute procedure public.set_current_timestamp_updated_at();

--- a/supabase/migrations/20240716123000_add_updated_by_to_daily_tasks.sql
+++ b/supabase/migrations/20240716123000_add_updated_by_to_daily_tasks.sql
@@ -1,0 +1,13 @@
+alter table public.daily_tasks
+  add column if not exists updated_by uuid references public.profiles (id) on delete set null;
+
+create index if not exists daily_tasks_updated_by_idx on public.daily_tasks (updated_by);
+
+update public.daily_tasks t
+set updated_by = t.user_id
+where updated_by is null
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = t.user_id
+  );


### PR DESCRIPTION
## Summary
- add a Supabase migration and hook to store and manage daily task checklists with carry-over logic
- build a new private workspace tab that lets supervisors update task status while admins verify and annotate remarks
- surface the assigned role in the header and provide a quick link back to the public site

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2862fd8908331aea7e0253390b15a