### PR TITLE
Revamp manpower logging form with shift and location selectors

### DIFF
--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import Card from "../components/Card";
 import DataTable from "../components/DataTable";
 import { useTable } from "../hooks/useTable";
+import { parseManpowerZone, splitManpowerNotes } from "../utils/manpower";
 import { usePublicDailyTasks } from "../hooks/usePublicDailyTasks";
 import {
   ResponsiveContainer,
@@ -108,6 +109,22 @@ export default function HomePage() {
     }
     return Object.entries(byDate).map(([date, workers]) => ({ date, workers }));
   }, [manpowerRows]);
+  const manpowerDisplayRows = React.useMemo(
+    () =>
+      manpowerRows.map((row) => {
+        const { level, zoneLetter, zoneNumber } = parseManpowerZone(row.zone);
+        const { photoUrl } = splitManpowerNotes(row.notes);
+        const zoneArea = zoneLetter ? `Zone ${zoneLetter}${zoneNumber ? `-${zoneNumber}` : ""}` : row.zone || "";
+        return {
+          ...row,
+          shift: row.hours || "",
+          level: level || "",
+          zone_area: zoneArea,
+          photo_url: photoUrl || "",
+        };
+      }),
+    [manpowerRows]
+  );
 
   const materialsByStatus = React.useMemo(() => {
     const byStatus = {};
@@ -571,8 +588,8 @@ export default function HomePage() {
             >
               <DataTable
                 caption="Recent manpower log entries"
-                columns={["date", "contractor", "trade", "workers", "hours", "zone", "supervisor"]}
-                rows={manpowerRows}
+                columns={["date", "contractor", "trade", "workers", "shift", "level", "zone_area", "supervisor", "photo_url"]}
+                rows={manpowerDisplayRows}
                 maxRows={8}
                 loading={manpowerLoading}
                 error={manpowerError}

--- a/src/utils/manpower.js
+++ b/src/utils/manpower.js
@@ -1,0 +1,64 @@
+export const SHIFT_OPTIONS = ["AM", "PM", "Evening"];
+export const LEVEL_OPTIONS = ["Basement", "L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8", "L9", "L10"];
+export const ZONE_LETTERS = ["A", "B", "C", "D", "E"];
+export const ZONE_NUMBERS = ["1", "2"];
+
+export function formatManpowerZone(level, zoneLetter, zoneNumber) {
+  const parts = [];
+  const trimmedLevel = (level || "").trim();
+  const trimmedZoneLetter = (zoneLetter || "").trim();
+  const trimmedZoneNumber = (zoneNumber || "").trim();
+
+  if (trimmedLevel) parts.push(`Level ${trimmedLevel}`);
+  if (trimmedZoneLetter) {
+    const zoneSuffix = trimmedZoneNumber ? `${trimmedZoneLetter}-${trimmedZoneNumber}` : trimmedZoneLetter;
+    parts.push(`Zone ${zoneSuffix}`);
+  }
+
+  return parts.join(" | ");
+}
+
+export function parseManpowerZone(value) {
+  if (!value) {
+    return { level: "", zoneLetter: "", zoneNumber: "" };
+  }
+
+  const levelMatch = value.match(/Level\s+([^|]+)/i);
+  const zoneMatch = value.match(/Zone\s+([A-Z])(?:-([0-9]+))?/i);
+
+  const level = levelMatch ? levelMatch[1].trim() : "";
+  const zoneLetter = zoneMatch ? zoneMatch[1].toUpperCase() : "";
+  const zoneNumber = zoneMatch && zoneMatch[2] ? zoneMatch[2].trim() : "";
+
+  return { level, zoneLetter, zoneNumber };
+}
+
+export function splitManpowerNotes(notes) {
+  if (!notes) {
+    return { notesText: "", photoUrl: "" };
+  }
+
+  const photoRegex = /Photo:\s*(\S+)/i;
+  const match = notes.match(photoRegex);
+  const photoUrl = match ? match[1].trim() : "";
+  let notesText = notes;
+
+  if (match) {
+    notesText = notes.replace(match[0], "");
+  }
+
+  notesText = notesText.replace(/\n{2,}/g, "\n").trim();
+
+  return { notesText, photoUrl };
+}
+
+export function buildManpowerNotes(notesText, photoUrl) {
+  const trimmedNotes = (notesText || "").trim();
+  const trimmedPhoto = (photoUrl || "").trim();
+  const segments = [];
+
+  if (trimmedNotes) segments.push(trimmedNotes);
+  if (trimmedPhoto) segments.push(`Photo: ${trimmedPhoto}`);
+
+  return segments.join("\n\n");
+}


### PR DESCRIPTION
## Summary
- replace manpower hour input with shift dropdown and add level, zone, and area selectors
- allow attaching a crew photo that is uploaded to Supabase storage and stored in the log notes
- expose shared helpers so dashboards show the new shift, level, zone/area, and photo metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e71ec930608331a6411da19c2e696a