### PR TITLE
Restore manpower hours compatibility

### DIFF
--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -571,7 +571,7 @@ export default function HomePage() {
             >
               <DataTable
                 caption="Recent manpower log entries"
-                columns={["date", "contractor", "trade", "workers", "hours", "zone", "supervisor"]}
+                columns={["date", "contractor", "trade", "workers", "shift", "level", "zone", "supervisor"]}
                 rows={manpowerRows}
                 maxRows={8}
                 loading={manpowerLoading}

--- a/supabase/migrations/20240720130000_update_manpower_shift_and_storage.sql
+++ b/supabase/migrations/20240720130000_update_manpower_shift_and_storage.sql
@@ -1,0 +1,96 @@
+DO $$
+BEGIN
+  IF to_regclass('public.manpower') IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'manpower' AND column_name = 'shift'
+    ) THEN
+      EXECUTE 'alter table public.manpower add column shift text';
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'manpower' AND column_name = 'hours'
+    ) THEN
+      EXECUTE 'update public.manpower set shift = coalesce(shift, hours::text) where shift is null and hours is not null';
+    END IF;
+
+    EXECUTE 'alter table public.manpower add column if not exists level text';
+    EXECUTE 'alter table public.manpower add column if not exists zone text';
+    EXECUTE 'alter table public.manpower add column if not exists photo_url text';
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM storage.buckets
+    WHERE id = 'manpower-photos'
+  ) THEN
+    PERFORM storage.create_bucket('manpower-photos', public => true);
+  END IF;
+END
+$$;
+
+DO $$
+DECLARE
+  policy_name text;
+BEGIN
+  policy_name := 'manpower_photos_public_read';
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects' AND policyname = policy_name
+  ) THEN
+    EXECUTE $$
+      create policy "manpower_photos_public_read"
+      on storage.objects
+      for select
+      using (bucket_id = 'manpower-photos')
+    $$;
+  END IF;
+
+  policy_name := 'manpower_photos_authenticated_insert';
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects' AND policyname = policy_name
+  ) THEN
+    EXECUTE $$
+      create policy "manpower_photos_authenticated_insert"
+      on storage.objects
+      for insert
+      to authenticated
+      with check (bucket_id = 'manpower-photos' and auth.uid() = owner)
+    $$;
+  END IF;
+
+  policy_name := 'manpower_photos_authenticated_update';
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects' AND policyname = policy_name
+  ) THEN
+    EXECUTE $$
+      create policy "manpower_photos_authenticated_update"
+      on storage.objects
+      for update
+      to authenticated
+      using (bucket_id = 'manpower-photos' and auth.uid() = owner)
+      with check (bucket_id = 'manpower-photos' and auth.uid() = owner)
+    $$;
+  END IF;
+
+  policy_name := 'manpower_photos_authenticated_delete';
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects' AND policyname = policy_name
+  ) THEN
+    EXECUTE $$
+      create policy "manpower_photos_authenticated_delete"
+      on storage.objects
+      for delete
+      to authenticated
+      using (bucket_id = 'manpower-photos' and auth.uid() = owner)
+    $$;
+  END IF;
+END
+$$;

--- a/supabase/migrations/20240721140000_restore_manpower_hours_column.sql
+++ b/supabase/migrations/20240721140000_restore_manpower_hours_column.sql
@@ -1,0 +1,40 @@
+DO $$
+BEGIN
+  IF to_regclass('public.manpower') IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'manpower' AND column_name = 'hours'
+    ) THEN
+      EXECUTE 'alter table public.manpower add column hours text';
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'manpower' AND column_name = 'shift'
+    ) THEN
+      EXECUTE 'update public.manpower set hours = shift where hours is distinct from shift';
+
+      EXECUTE $fn$
+        create or replace function public.manpower_sync_hours()
+        returns trigger
+        language plpgsql
+        as $body$
+        begin
+          new.hours := new.shift;
+          return new;
+        end;
+        $body$;
+      $fn$;
+
+      EXECUTE 'drop trigger if exists manpower_sync_hours on public.manpower';
+
+      EXECUTE $tr$
+        create trigger manpower_sync_hours
+        before insert or update on public.manpower
+        for each row
+        execute function public.manpower_sync_hours()
+      $tr$;
+    END IF;
+  END IF;
+END
+$$;


### PR DESCRIPTION
## Summary
- retain the legacy manpower.hours data for existing environments while keeping shift as the primary field
- backfill and sync the hours column via a new migration to avoid schema cache errors
- expose the new shift and level fields in the public dashboard and align inserts with both columns

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e71ec930608331a6411da19c2e696a