### PR TITLE
Handle manpower upload errors for missing columns and buckets

### DIFF
--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -117,7 +117,7 @@ export default function HomePage() {
         const zoneArea = zoneLetter ? `Zone ${zoneLetter}${zoneNumber ? `-${zoneNumber}` : ""}` : row.zone || "";
         return {
           ...row,
-          shift: row.hours || "",
+          shift: row.shift || row.hours || "",
           level: level || "",
           zone_area: zoneArea,
           photo_url: photoUrl || "",


### PR DESCRIPTION
## Summary
- add a configurable/fallback bucket list for manpower photo uploads
- insert manpower logs using the shift column and retry without the legacy hours column when needed
- normalize manpower displays to read from the shift column when present

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7428aad888331a88d3525fba458a9